### PR TITLE
아큐언트 모듈 수정

### DIFF
--- a/AcuantCamera/AcuantCamera/Camera/CameraOptions.swift
+++ b/AcuantCamera/AcuantCamera/Camera/CameraOptions.swift
@@ -31,7 +31,7 @@ import UIKit
          bracketLengthInVertical: Int = 50,
          defaultBracketMarginWidth: CGFloat = 0.5,
          defaultBracketMarginHeight: CGFloat = 0.6,
-         textForCameraPaused: String = "CAMERA PAUSED",
+         textForCameraPaused: String = NSLocalizedString("acuant_camera_paused", comment: ""),
          backButtonText: String = "BACK") {
         self.hideNavigationBar = hideNavigationBar
         self.showBackButton = showBackButton

--- a/AcuantCamera/AcuantCamera/Camera/CameraViewController.swift
+++ b/AcuantCamera/AcuantCamera/Camera/CameraViewController.swift
@@ -226,15 +226,12 @@ import AVFoundation
     }
 
     private func addNavigationBackButton() {
-        backButton = UIButton(frame: CGRect(x: 0, y: UIScreen.main.heightOfSafeArea() * 0.065, width: 90, height: 40))
+        backButton = UIButton(frame: CGRect(x: 10, y: self.view.safeAreaInsets.top, width: 44, height: 50)) // 와바 네비게이션 뷰랑 동일하게 맞춤
 
-        var attribs: [NSAttributedString.Key: Any?] = [:]
-        attribs[NSAttributedString.Key.font] = UIFont.systemFont(ofSize: 18)
-        attribs[NSAttributedString.Key.foregroundColor] = UIColor.white
-        attribs[NSAttributedString.Key.baselineOffset] = 4
+        let backButtonImage: UIImage? = .init(named: "ic_back_nor")?.withRenderingMode(.alwaysTemplate)
 
-        let str = NSMutableAttributedString.init(string: options.backButtonText, attributes: attribs as [NSAttributedString.Key: Any])
-        backButton.setAttributedTitle(str, for: .normal)
+        backButton.setImage(backButtonImage, for: .normal)
+        backButton.tintColor = .white
         backButton.addTarget(self, action: #selector(backTapped(_:)), for: .touchUpInside)
         backButton.isOpaque = true
         backButton.imageView?.contentMode = .scaleAspectFit

--- a/AcuantCamera/AcuantCamera/Camera/Document/DocumentCameraOptions.swift
+++ b/AcuantCamera/AcuantCamera/Camera/Document/DocumentCameraOptions.swift
@@ -29,12 +29,12 @@
                 defaultBracketMarginHeight: CGFloat = 0.6,
                 textForState: @escaping (DocumentCameraState) -> String = { state in
                     switch state {
-                    case .align: return "ALIGN"
-                    case .moveCloser: return "MOVE CLOSER"
-                    case .tooClose: return "TOO CLOSE"
-                    case .steady: return "HOLD STEADY"
-                    case .hold: return "HOLD"
-                    case .capture: return "CAPTURING"
+                    case .align: return NSLocalizedString("acuant_camera_align", comment: "")
+                    case .moveCloser: return NSLocalizedString("acuant_camera_move_closer", comment: "")
+                    case .tooClose: return NSLocalizedString("acuant_camera_outside_view", comment: "")
+                    case .steady: return NSLocalizedString("acuant_camera_hold_steady", comment: "")
+                    case .hold: return "HOLD" // 기존에 사용처가없음
+                    case .capture: return NSLocalizedString("acuant_camera_capturing", comment: "")
                     @unknown default: return ""
                     }
                 },
@@ -49,8 +49,8 @@
                     @unknown default: return UIColor.black.cgColor
                     }
                 },
-                textForManualCapture: String = "ALIGN & TAP",
-                textForCameraPaused: String = "CAMERA PAUSED",
+                textForManualCapture: String = NSLocalizedString("acuant_camera_manual_capture", comment: ""),
+                textForCameraPaused: String = NSLocalizedString("acuant_camera_paused", comment: ""),
                 backButtonText: String = "BACK") {
         self.countdownDigits = countdownDigits
         self.timeInMillisecondsPerCountdownDigit = timeInSecondsPerCountdownDigit


### PR DESCRIPTION
## Description
- Acuant 모듈내 텍스트에 번역값을 적용한 PR입니다
- Back버튼은 기획팀에 문의하여 번역문구를 적용시키던것에서 `<`이미지를 적용시키는것으로 변경하였습니다.

## Todos
- [x] localized 적용
- [x] Back 버튼 수정 

## 테스트 해본 시나리오
- 근접, 원거리, 포커싱, 캡쳐 상태에서 정상적으로번역값이 나오는지

## 테스트 결과 영상

## 모듈 업데이트 이후
| 텍스트 번역 미적용시 | 텍스트 번역 적용시|
| --- | --- |
| <kbd><video src="https://github.com/wirebarley/iOSSDKV11/assets/99154057/ff342e3b-b10d-4785-875d-02b9c2267d43" width="255" /></kbd> | <kbd><video src="https://github.com/wirebarley/iOSSDKV11/assets/99154057/a9a93a4d-26b2-440a-a037-08e660edf506" width="255" /></kbd> | 










## Notice
주의사항

## Issue 연결
close : wirebarley/wb-ios#2190
QA 이슈 : wirebarley/QA#
